### PR TITLE
Add geocaml organisation

### DIFF
--- a/list-of-adopters.md
+++ b/list-of-adopters.md
@@ -8,3 +8,4 @@ following projects/spaces have adopted this Code of Conduct -
 * [ocaml/dune](https://github.com/ocaml/dune) in [ocaml/dune#6875](https://github.com/ocaml/dune/pull/6875)
 * [ocaml/opam](https://github.com/ocaml/opam) in [ocaml/opam#5419](https://github.com/ocaml/opam/pull/5419)
 * [watch.ocaml.org](https://watch.ocaml.org) see [the instance information](https://watch.ocaml.org/about/instance#code-of-conduct)
+* [geocaml organisation](https://github.com/geocaml) see [the organisation's profile](https://github.com/geocaml/.github)


### PR DESCRIPTION
Hello 👋 

I would like to adopt the OCaml code of conduct for all of the projects in the [geocaml organisation](https://github.com/geocaml). I feel the organisation is now at the point of not being too new to do so given:

 - It has released opam libraries including [geojson](https://github.com/geocaml/ocaml-geojson), [ISO3166](https://github.com/geocaml/ISO3166) and [topojson](https://github.com/geocaml/ocaml-topojson).
 - Two of the repositories have been used in previous [outreachy internships](https://www.outreachy.org).

I have a few questions though:

 1. Is it okay to have this blanket statement "We follow the OCaml community's code of conduct, see [our copy in this repository](https://github.com/geocaml/.github/blob/main/profile/CODE_OF_CONDUCT.md). This applies to all repositories under the Geocaml organisation (even if they don't have a CODE_OF_CONDUCT.md in the source code yet)." -- note the 'yet', I do plan to add the CODE_OF_CONDUCT.md to each repository but I would like the whole organisation to follow the code of conduct in general (e.g. Github Discussions, which I might use at some point).
 2. I would like to include the Code of Conduct team's contact details for reporting Code of Conduct violations in the geocaml code of conduct because at the moment the sole member of the organisation (me) is also the only person to contact in case of violations which seems like a bad idea.
 
Thanks again for all of the effort in creating the code of conduct and the committee.