### PR TITLE
Added Sandmark and current-bench to the list of adopters

### DIFF
--- a/list-of-adopters.md
+++ b/list-of-adopters.md
@@ -5,6 +5,7 @@ In addition to the spaces listed in the
 following projects/spaces have adopted this Code of Conduct -
 
 * [geocaml organisation](https://github.com/geocaml) see [the organisation's profile](https://github.com/geocaml/.github)
+* [ocaml-bench/sandmark](https://github.com/ocaml-bench/sandmark)
 * [ocaml-multicore/domainslib](https://github.com/ocaml-multicore/domainslib)
 * [ocaml-multicore/eio](https://github.com/ocaml-multicore/eio)
 * [ocaml-multicore/lockfree](https://github.com/ocaml-multicore/lockfree/pull/71)
@@ -13,6 +14,7 @@ following projects/spaces have adopted this Code of Conduct -
 * [ocaml/ocaml](https://github.com/ocaml/ocaml) in [ocaml/ocaml#11761](https://github.com/ocaml/ocaml/pull/11761)
 * [ocaml/opam](https://github.com/ocaml/opam) in [ocaml/opam#5419](https://github.com/ocaml/opam/pull/5419)
 * [ocaml/setup-ocaml](https://github.com/ocaml/setup-ocaml)
+* [ocurrent/current-bench](https://github.com/ocurrent/current-bench)
 * [tarides/dune-release](https://github.com/tarides/dune-release) in [tarides/dune-release#474](https://github.com/tarides/dune-release/pull/474)
 * [tarides/opam-monorepo](https://github.com/tarides/opam-monorepo) in [tarides/opam-monorepo#391](https://github.com/tarides/opam-monorepo/pull/391)
 * [watch.ocaml.org](https://watch.ocaml.org) see [the instance information](https://watch.ocaml.org/about/instance#code-of-conduct)


### PR DESCRIPTION
Both Sandmark and current-bench have adopted the OCaml Code of Conduct mid-May.